### PR TITLE
feat: add alter_topic_config tool

### DIFF
--- a/internal/kafka/client.go
+++ b/internal/kafka/client.go
@@ -105,6 +105,14 @@ type DescribeConfigsResult struct {
 	ErrorMessage string        `json:"error_message,omitempty"`
 }
 
+// AlterTopicConfigResult holds the result of an alter topic config operation.
+type AlterTopicConfigResult struct {
+	Topic        string            `json:"topic"`
+	Configs      map[string]string `json:"configs"`
+	ErrorCode    int16             `json:"error_code,omitempty"`
+	ErrorMessage string            `json:"error_message,omitempty"`
+}
+
 // ClusterOverviewResult holds high-level cluster health information.
 type ClusterOverviewResult struct {
 	ControllerID                   int32   `json:"controller_id"`
@@ -990,6 +998,53 @@ func (c *Client) GetClusterOverview(ctx context.Context) (*ClusterOverviewResult
 	}
 
 	return overview, nil
+}
+
+// AlterTopicConfig modifies configuration settings on an existing topic
+// using the IncrementalAlterConfigs API (Kafka 2.3+).
+func (c *Client) AlterTopicConfig(ctx context.Context, topic string, configs map[string]string) (*AlterTopicConfigResult, error) {
+	req := kmsg.NewIncrementalAlterConfigsRequest()
+	resource := kmsg.NewIncrementalAlterConfigsRequestResource()
+	resource.ResourceType = kmsg.ConfigResourceType(ConfigResourceTypeTopic)
+	resource.ResourceName = topic
+
+	for key, value := range configs {
+		cfg := kmsg.NewIncrementalAlterConfigsRequestResourceConfig()
+		cfg.Name = key
+		cfg.Op = kmsg.IncrementalAlterConfigOpSet
+		cfg.Value = kmsg.StringPtr(value)
+		resource.Configs = append(resource.Configs, cfg)
+	}
+	req.Resources = append(req.Resources, resource)
+
+	resp, err := c.kgoClient.Request(ctx, &req)
+	if err != nil {
+		return nil, fmt.Errorf("IncrementalAlterConfigs request failed: %w", err)
+	}
+	alterResp, ok := resp.(*kmsg.IncrementalAlterConfigsResponse)
+	if !ok {
+		return nil, fmt.Errorf("unexpected response type for IncrementalAlterConfigs request")
+	}
+
+	for _, res := range alterResp.Resources {
+		if res.ErrorCode != 0 {
+			errMsg := kerr.ErrorForCode(res.ErrorCode)
+			detail := ""
+			if res.ErrorMessage != nil {
+				detail = *res.ErrorMessage
+			}
+			return &AlterTopicConfigResult{
+				Topic:        topic,
+				ErrorCode:    res.ErrorCode,
+				ErrorMessage: detail,
+			}, fmt.Errorf("failed to alter config for topic '%s': %w", topic, errMsg)
+		}
+	}
+
+	return &AlterTopicConfigResult{
+		Topic:   topic,
+		Configs: configs,
+	}, nil
 }
 
 // Close gracefully shuts down the Kafka client.

--- a/internal/kafka/interface.go
+++ b/internal/kafka/interface.go
@@ -40,6 +40,9 @@ type KafkaClient interface {
 	// StringToResourceType converts a string resource type to its corresponding ConfigResourceType
 	StringToResourceType(resourceTypeStr string) (ConfigResourceType, error)
 
+	// AlterTopicConfig modifies configuration settings on an existing topic.
+	AlterTopicConfig(ctx context.Context, topic string, configs map[string]string) (*AlterTopicConfigResult, error)
+
 	// Close gracefully shuts down the Kafka client.
 	Close()
 }

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -370,5 +370,62 @@ func RegisterTools(s *server.MCPServer, kafkaClient kafka.KafkaClient, cfg confi
 		return mcp.NewToolResultText(string(jsonData)), nil
 	})
 
-	// TODO: Add admin tools (create_topic, delete_topic, etc.)
+	// --- alter_topic_config tool ---
+	alterTopicConfigTool := mcp.NewTool("alter_topic_config",
+		mcp.WithDescription("Modifies configuration settings on an existing Kafka topic. Use this tool to change retention policies, cleanup policies, segment sizes, and other topic-level settings. Only the specified config keys are changed; all other configs remain unchanged. Use describe_configs to verify changes afterward."),
+		mcp.WithString("topic", mcp.Required(), mcp.Description("The name of the Kafka topic whose configuration will be modified. Must be an existing topic.")),
+		mcp.WithObject("configs", mcp.Required(), mcp.Description("A JSON object of configuration key-value pairs to set. Example: {\"retention.ms\": \"86400000\", \"cleanup.policy\": \"compact\"}. All values must be strings.")),
+	)
+
+	s.AddTool(alterTopicConfigTool, func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		topic := req.GetString("topic", "")
+		if topic == "" {
+			return mcp.NewToolResultError("Missing required parameter: topic"), nil
+		}
+
+		// Extract configs from the request arguments
+		args, ok := req.Params.Arguments.(map[string]interface{})
+		if !ok {
+			return mcp.NewToolResultError("Invalid request arguments"), nil
+		}
+		configsRaw, ok := args["configs"]
+		if !ok {
+			return mcp.NewToolResultError("Missing required parameter: configs"), nil
+		}
+		configsMap, ok := configsRaw.(map[string]interface{})
+		if !ok {
+			return mcp.NewToolResultError("Parameter 'configs' must be a JSON object of key-value pairs"), nil
+		}
+		if len(configsMap) == 0 {
+			return mcp.NewToolResultError("Parameter 'configs' must contain at least one config key-value pair"), nil
+		}
+
+		configs := make(map[string]string, len(configsMap))
+		for k, v := range configsMap {
+			strVal, ok := v.(string)
+			if !ok {
+				return mcp.NewToolResultError(fmt.Sprintf("Config value for key '%s' must be a string", k)), nil
+			}
+			configs[k] = strVal
+		}
+
+		slog.InfoContext(ctx, "Executing alter_topic_config tool", "topic", topic, "configKeys", len(configs))
+
+		result, err := kafkaClient.AlterTopicConfig(ctx, topic, configs)
+		if err != nil {
+			slog.ErrorContext(ctx, "Failed to alter topic config", "topic", topic, "error", err)
+			if result != nil && result.ErrorMessage != "" {
+				return mcp.NewToolResultError(fmt.Sprintf("Failed to alter config for topic '%s': %s", topic, result.ErrorMessage)), nil
+			}
+			return mcp.NewToolResultError(fmt.Sprintf("Failed to alter config for topic '%s': %v", topic, err)), nil
+		}
+
+		slog.InfoContext(ctx, "Successfully altered topic config", "topic", topic)
+
+		jsonData, marshalErr := json.MarshalIndent(result, "", "  ")
+		if marshalErr != nil {
+			return mcp.NewToolResultError("Internal server error: failed to marshal results"), nil
+		}
+		return mcp.NewToolResultText(string(jsonData)), nil
+	})
 }


### PR DESCRIPTION
 ## Summary

  - Adds `alter_topic_config` tool that allows agents to modify configuration settings on existing Kafka topics (e.g., retention.ms, cleanup.policy, segment.bytes)
  - Uses Kafka's IncrementalAlterConfigs API (Kafka 2.3+), which only modifies specified keys and leaves all other configs unchanged
  - Returns the updated config key-value pairs on success, or a detailed error message on failure

## Changes
- `internal/kafka/interface.go`: Added `AlterTopicConfig` method to the `KafkaClient` interface
- `internal/kafka/client.go`: Added `AlterTopicConfigResult` type and implemented the method using franz-go's `IncrementalAlterConfigsRequest`
- `internal/mcp/tools.go`: Registered the MCP tool with topic and configs parameters, including validation that config values are strings

## Test plan
- [x] Altered `retention.ms` on a test topic — verified change via `describe_configs`
- [ ] - [x] Verified only specified config keys are changed, other configs remain untouched
- [ ] - [x] Verified error handling for non-existent topics

## Issues
Closes #80

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the ability to modify Kafka topic configurations with a new tool that accepts a topic name and configuration key/value pairs, returning detailed alteration results with error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->